### PR TITLE
fixed for llama use case

### DIFF
--- a/cycling_utils/saving.py
+++ b/cycling_utils/saving.py
@@ -67,7 +67,6 @@ class AtomicDirectory:
         self.cleanup = cleanup
 
     def prepare_checkpoint_directory(self):
-        # if int(os.environ["RANK"]) == 0:
         # Catalogue any checkpoint directories already in the output_directory
         checkpoints = [
             d
@@ -132,8 +131,6 @@ class AtomicDirectory:
             ), "ERROR: fault creating new save dir."
         # Return path to save to
         return next_checkpoint_directory
-        # else:
-        #     return None
 
     def atomic_symlink(self, checkpoint_directory):
         if int(os.environ["RANK"]) == 0:


### PR DESCRIPTION
Fixing so that the new checkpoint directory returned by prepare_checkpoint_directory() is available on all ranks.